### PR TITLE
enable single filter for attribute type tags

### DIFF
--- a/src/system/modules/metamodelsfilter_select/config/config.php
+++ b/src/system/modules/metamodelsfilter_select/config/config.php
@@ -23,6 +23,7 @@ $GLOBALS['METAMODELS']['filters']['select']['image']         = 'system/modules/m
 $GLOBALS['METAMODELS']['filters']['select']['info_callback'] = array('MetaModels\Dca\Filter', 'infoCallback');
 $GLOBALS['METAMODELS']['filters']['select']['attr_filter'][] = 'select';
 $GLOBALS['METAMODELS']['filters']['select']['attr_filter'][] = 'text';
+$GLOBALS['METAMODELS']['filters']['select']['attr_filter'][] = 'tags';
 
 // non composerized Contao 2.X autoload support.
 $GLOBALS['MM_AUTOLOAD'][] = dirname(__DIR__);


### PR DESCRIPTION
In my testcase with C3.1.2 the filtering work as expectet for the templates default|linklist, I got problems with checkbox|radio but this is because i use iCheck to change the appearance of those elements.

Would be great if anyone else could have a look at the checkbox|radio templates.
